### PR TITLE
Define higher z-index for CSS class 'box'

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,6 +137,7 @@ a.ref {
   margin-left: 3rem;
   padding: 1em;
   width: 19em;
+  z-index: 2;
 }
 
 .box + .box {


### PR DESCRIPTION
Without this fix, the registration link does not work since it is obscured by the #goals anchor from `<h2 id="goals">`.

Only folks who know how to use web inspector have been able to register to date (or those who found the "registration form" link down below that takes them to the same place).

<img width="1264" alt="Screen Shot 2020-01-27 at 15 14 51" src="https://user-images.githubusercontent.com/765510/73178820-b92e5d00-411a-11ea-9501-8a3a6690672d.png">
