### PR TITLE
Make sure main content anchors and box links do not overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,6 +80,7 @@ a:hover {
 a.ref,
 .has-ref {
   cursor: pointer;
+  display: inline;
 }
 
 a.ref {


### PR DESCRIPTION
Without this fix, the registration link does not work since it is obscured by the #goals anchor from <h2 id="goals">

This is a better fix.