### PR TITLE
Add 'How to apply to speak?' section header

### DIFF
--- a/speakers.html
+++ b/speakers.html
@@ -68,8 +68,10 @@
         <section>
           <h2 id=who>Who should apply to speak at the workshop?</h2>
           <p>W3C is convening this virtual workshop to build a shared understanding of how the Machine Learning ecosystem intersects with the Web browsers and help chart its standardization roadmap.</p>
-
-          <p id=submit>If your experience or expertise in the field has provided you with insights (questions or answers) about this intersection, in particular about the <a href="./#topics">topics in scope of the workshop</a>, please <a href="mailto:group-machine-learning-pc@w3.org">contact the Program Committee</a> <strong>before July 3rd, 2020</strong> and we will work with you in confirming and defining your proposed contribution.</p>
+        </speaker>
+        <section>
+          <h2 id=submit>How to apply to speak?</h2>
+          <p>If your experience or expertise in the field has provided you with insights (questions or answers) about this intersection, in particular about the <a href="./#topics">topics in scope of the workshop</a>, please <a href="mailto:group-machine-learning-pc@w3.org">contact the Program Committee</a> <strong>before July 3rd, 2020</strong> and we will work with you in confirming and defining your proposed contribution.</p>
         </section>
         <section>
           <h2 id=why>Why should I apply to speak?</h2>


### PR DESCRIPTION
I felt this makes these instructions more clear especially when landing on this page via the `#submit` anchor.

@dom feel free to merge right away if this seems right and work on translations in parallel.