### PR TITLE
Tell PDF.js viewer to render text and annotations layers

### DIFF
--- a/_layouts/talk.html
+++ b/_layouts/talk.html
@@ -9,6 +9,9 @@
     {% if page.format == "shower" %}
     <link rel="stylesheet" href="https://www.w3.org/2020/Talks/fd-media-processing/template/slides.css">
     {% endif %}
+    {% if page.format == "pdf" %}
+    <link rel="stylesheet" href="https://unpkg.com/pdfjs-dist@2.5.207/web/pdf_viewer.css">
+    {% endif %}
     <link rel="stylesheet" href="../style.css">
     <link rel="stylesheet" href="../presentation-viewer.css">
     <link rel="stylesheet" href="../tooltip.css">
@@ -145,7 +148,8 @@
     </script>
     <script src="../webvtt-parser.js"></script>
     {% if page.format == "pdf" %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.5.207/pdf.js"></script>
+    <script src="https://unpkg.com/pdfjs-dist@2.5.207/build/pdf.js"></script>
+    <script src="https://unpkg.com/pdfjs-dist@2.5.207/web/pdf_viewer.js"></script>
     {% endif %}
     <script src="../presentation-viewer.js"></script>
     {% if page.format == "pdf" %}

--- a/pdf-loader.js
+++ b/pdf-loader.js
@@ -2,7 +2,7 @@ var pdfjsLib = window['pdfjs-dist/build/pdf'];
 var pdfjsViewer = window['pdfjs-dist/web/pdf_viewer'];
 
 // The workerSrc property shall be specified.
-pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://unpkg.com/pdfjs-dist@2.5.207/build/pdf.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://unpkg.com/pdfjs-dist@2.5.207/build/pdf.worker.js';
 
 const firstPdfSlide = document.querySelector('[data-fmt="pdf"][data-src]');
 if (firstPdfSlide) {

--- a/pdf-loader.js
+++ b/pdf-loader.js
@@ -1,37 +1,37 @@
 var pdfjsLib = window['pdfjs-dist/build/pdf'];
+var pdfjsViewer = window['pdfjs-dist/web/pdf_viewer'];
 
 // The workerSrc property shall be specified.
-pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.5.207/pdf.worker.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://unpkg.com/pdfjs-dist@2.5.207/build/pdf.js';
 
 const firstPdfSlide = document.querySelector('[data-fmt="pdf"][data-src]');
 if (firstPdfSlide) {
   const url = firstPdfSlide.dataset.src.split('#')[0];
   var loadingTask = pdfjsLib.getDocument(url);
+  var eventBus = new pdfjsViewer.EventBus();
   loadingTask.promise.then(function(pdf) {
     [...document.querySelectorAll('div[data-fmt="pdf"][data-src][id^="slide-"]')].forEach(div => {
       // Fetch the first page
       var pageNumber = parseInt(div.id.slice(6));
       pdf.getPage(pageNumber).then(function(page) {
-        var canvas = document.createElement("canvas");
-        div.appendChild(canvas);
-        canvas.height = div.clientHeight;
-        let scale = (canvas.height / page.view[3]);
-        let viewport = page.getViewport({scale: scale});
-        canvas.width = page.view[2] * scale;
-
-        // Prepare canvas using PDF page dimensions
-        var context = canvas.getContext('2d');
-        canvas.height = viewport.height;
-        canvas.width = viewport.width;
-
-        // Render PDF page into canvas context
-        var renderContext = {
-          canvasContext: context,
-          viewport: viewport
-        };
-        var renderTask = page.render(renderContext);
-        renderTask.promise.then(function () {
+        // Make slides fit the available space (Note the need to convert from
+        // CSS points to CSS pixels for page dimensions)
+        const scale = Math.min(
+          div.clientHeight / page.view[3],
+          div.clientWidth / page.view[2]) * 72 / 96;
+        const viewport = page.getViewport({ scale });
+        var pdfPageView = new pdfjsViewer.PDFPageView({
+          container: div,
+          id: pageNumber,
+          scale: scale,
+          defaultViewport: viewport,
+          eventBus: eventBus,
+          textLayerFactory: new pdfjsViewer.DefaultTextLayerFactory(),
+          annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory()
         });
+        // Associates the actual page with the view, and drawing it
+        pdfPageView.setPdfPage(page);
+        return pdfPageView.draw();
       });
     });
   }, function (reason) {

--- a/presentation-viewer.css
+++ b/presentation-viewer.css
@@ -197,3 +197,9 @@
       .slide.iframe {
           /*height: 26em;*/
       }
+
+/**
+ * Following rule is needed for PDF.js to position the text layer correctly
+ * relative to the canvas
+ */
+.slide .page { position: relative; }


### PR DESCRIPTION
PDF slides were rendered as opaque canvas. This update tells the PDF.js viewer to also render a text layer (with links) on top of the canvas. In turn, this makes at least the textual content of the slides available to accessibility agents, and lets users copy and paste slide text and click on links.

I note I tested the update on a local copy of a presentation page to ease debugging, and not on the actual code here which I'm not sure how to run locally. Hopefully, I didn't forget anything when preparing the PR :)