### PR TITLE
Fix styling of toc

### DIFF
--- a/presentations.html
+++ b/presentations.html
@@ -7,7 +7,7 @@ layout: subpage
 
   <p>As you watch these videos in preparation for the live sessions, please contribute to the discussions emerging from the presentations in <a href="https://github.com/w3c/machine-learning-workshop/issues">our GitHub repository issues</a>, either by creating a new issue or commenting on an existing one.</p>
   
-  <ol id=toc>
+  <ol id=toc style="margin-left: 1.4rem;">
     <li><a href="#opp">Opportunities and Challenges of Browser-Based Machine Learning</a></li>
     <li><a href="#foundations">Web Platform Foundations for Machine Learning</a></li>
     <li><a href="#dev">Machine Learning Experiences on the Web: A <strong>Developer</strong>'s Perspective</a></li>


### PR DESCRIPTION
https://www.w3.org/2020/06/machine-learning-workshop/presentations.html

We should leave some space for the marker.